### PR TITLE
feat: Add find_middle_node() method for linked lists

### DIFF
--- a/cpp_code/src/CMakeLists.txt
+++ b/cpp_code/src/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory (./datastructures)
+add_subdirectory (./leetcode_exercises)

--- a/cpp_code/src/leetcode_exercises/CMakeLists.txt
+++ b/cpp_code/src/leetcode_exercises/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory (./find_middle_node)

--- a/cpp_code/src/leetcode_exercises/find_middle_node/CMakeLists.txt
+++ b/cpp_code/src/leetcode_exercises/find_middle_node/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Find clang-tidy if available
+find_program(CLANG_TIDY_EXE NAMES "clang-tidy")
+
+# Set clang-tidy arguments
+if(CLANG_TIDY_EXE)
+    set(
+        CLANG_TIDY_COMMAND
+        "${CLANG_TIDY_EXE}"
+        "clang-diagnostic-*,clang-analyzer-*,readability-*,performance-*"
+        )
+endif()
+
+add_executable (
+    find_middle_node
+    find_middle_node.cpp
+)
+
+set_target_properties(
+    find_middle_node
+    PROPERTIES
+    C_CLANG_TIDY
+    "${CLANG_TIDY_COMMAND}"
+    )
+target_compile_features (find_middle_node PRIVATE cxx_std_17)

--- a/cpp_code/src/leetcode_exercises/find_middle_node/README.md
+++ b/cpp_code/src/leetcode_exercises/find_middle_node/README.md
@@ -1,0 +1,29 @@
+# Find the Middle Node
+
+## Description
+
+The `find_middle_node()` method aims to determine the index of the middle node within a linked list. It employs the slow and fast pointer technique, ensuring optimal performance.
+
+## Features
+
+1. **Handling Empty Lists**: If the linked list is empty, the method returns -1, providing a clear indication of an invalid scenario.
+
+2. **Even Number of Elements**: For linked lists with an even number of elements, the method returns the index of the second middle node. This consideration enhances the applicability of the method across various scenarios.
+
+## Implementation
+
+The algorithmic approach involves initializing two pointers, a slow and a fast one. The slow pointer advances one step at a time, while the fast pointer moves two steps at a time. This allows for efficient traversal, culminating in the identification of the middle node.
+
+## Usage
+
+```cpp
+#include "linkedlist.h"  // Include your linked list header file
+
+// ...
+
+LinkedList myList;
+// Populate the linked list
+
+int middleIndex = myList.find_middle_node();
+// Handle the result accordingly
+```

--- a/cpp_code/src/leetcode_exercises/find_middle_node/find_middle_node.cpp
+++ b/cpp_code/src/leetcode_exercises/find_middle_node/find_middle_node.cpp
@@ -1,0 +1,86 @@
+/* ==========================================================================
+ * linkedlist.c - Main program file demonstrating linked list functionality.
+ *
+ *  Copyright (C) 2023 Ljubomir Kurij <ljubomir_kurij@protonmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ========================================================================== */
+
+
+/* ==========================================================================
+ *
+ * 2023-11-28 Ljubomir Kurij <ljubomir_kurij@protonmail.com>
+ *
+ * * linkedlist.c: created.
+ *
+ * ========================================================================== */
+
+
+/* ==========================================================================
+ * Headers include section
+ * ========================================================================== */
+
+/* Standard Library headers */
+#include <cstdlib>
+#include <iostream>
+
+/* Project headers */
+#include "linkedlist.hpp"
+
+
+/* ==========================================================================
+ * Main function
+ * ========================================================================== */
+int main(int argc, char *argv[])
+{
+    /* Create an empty linked list */
+    std::cout << "Creating an empty linked list..." << std::endl;
+    LinkedList *list = new LinkedList();
+    std::cout << "List: " << list->string() << std::endl;
+    std::cout << "Test if find_middle_node() works on an empty list..." << std::endl;
+    std::cout << "Middle node: " << list->find_middle_node() << std::endl << std::endl;
+
+    /* Add a node to the list */
+    std::cout << "Adding a node to the list..." << std::endl;
+    list->append(0);
+    std::cout << "List: " << list->string() << std::endl;
+    std::cout << "Test if find_middle_node() works on a list with one node..."
+        << std::endl;
+    std::cout << "Middle node: " << list->find_middle_node() << std::endl << std::endl;
+
+    /* Expand list to have even number of nodes */
+    std::cout << "Expanding list to have even number of nodes..." << std::endl;
+    list->append(1);
+    list->append(2);
+    list->append(3);
+    std::cout << "List: " << list->string() << std::endl;
+    std::cout << "Test if find_middle_node() works on a list with even number of "
+        "nodes..." << std::endl;
+    std::cout << "Middle node: " << list->find_middle_node() << std::endl << std::endl;
+
+    /* Expand list to have odd number of nodes */
+    std::cout << "Expanding list to have odd number of nodes..." << std::endl;
+    list->append(4);
+    std::cout << "List: " << list->string() << std::endl;
+    std::cout << "Test if find_middle_node() works on a list with odd number of "
+        "nodes..." << std::endl;
+    std::cout << "Middle node: " << list->find_middle_node() << std::endl << std::endl;
+
+    /* Delete list */
+    std::cout << "Deleting list..." << std::endl;
+    delete list;
+
+    return EXIT_SUCCESS;
+}

--- a/cpp_code/src/leetcode_exercises/find_middle_node/linkedlist.hpp
+++ b/cpp_code/src/leetcode_exercises/find_middle_node/linkedlist.hpp
@@ -1,0 +1,333 @@
+/* ==========================================================================
+ * linkedlist.hpp - A header only implementation of a linked list.
+ *
+ *  Copyright (C) 2023 Ljubomir Kurij <ljubomir_kurij@protonmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ========================================================================== */
+
+
+/* ==========================================================================
+ *
+ * 2023-12-02 Ljubomir Kurij <ljubomir_kurij@protonmail.com>
+ *
+ * * linkedlist.hpp: created.
+ *
+ * ========================================================================== */
+
+
+#ifndef LINKEDLIST_HPP
+#define LINKEDLIST_HPP
+
+
+/* ==========================================================================
+ * Headers include section
+ * ========================================================================== */
+
+/* Standard Library headers */
+#include <iostream>
+#include <string>
+
+
+/* ==========================================================================
+ * Abstract Data Types Definition Section
+ * ========================================================================== */
+class LinkedList {
+private:
+    /* Inner classes */
+    class Node {
+    private:
+        /* data */
+        int data_;
+        Node *next_;
+
+    public:
+        Node(int data) : data_(data), next_(nullptr) {};
+        ~Node() {};
+        void print(void);
+        std::string string();
+        void data(int data);
+        int data(void);
+        void next(Node *next);
+        Node *next(void);
+    };
+
+private:
+    /* data */
+    LinkedList::Node *head_;
+    LinkedList::Node *tail_;
+    int size_;
+
+public:
+    LinkedList();
+    ~LinkedList();
+    void print(void);
+    std::string string(void);
+    void append(int data);
+    void prepend(int data);
+    void insert(int data, int index);
+    Node *remove(int index);
+    Node *get(int index);
+    int size(void);
+    void set(int data, int index);
+    Node *pop_back(void);
+    Node *pop_front(void);
+    void reverse(void);
+    int find_middle_node(void);
+};
+
+
+/* ==========================================================================
+ * Methods Definitions Section
+ * ========================================================================== */
+void LinkedList::Node::print(void) {
+    std::cout << this->string() << std::endl;
+}
+
+std::string LinkedList::Node::string(void) {
+    std::string str = "Node(" + std::to_string(this->data()) + ")";
+    return str;
+}
+
+void LinkedList::Node::data(int data) {
+    this->data_ = data;
+}
+
+int LinkedList::Node::data(void) {
+    return this->data_;
+}
+
+void LinkedList::Node::next(Node *next) {
+    this->next_ = next;
+}
+
+LinkedList::Node *LinkedList::Node::next(void) {
+    return this->next_;
+}
+
+LinkedList::LinkedList() {
+    this->head_ = nullptr;
+    this->tail_ = nullptr;
+    this->size_ = 0;
+}
+
+LinkedList::~LinkedList() {
+    LinkedList::Node *current = this->head_;
+    LinkedList::Node *next = nullptr;
+    while (current != nullptr) {
+        next = current->next();
+        delete current;
+        current = next;
+    }
+    this->head_ = nullptr;
+    this->tail_ = nullptr;
+    this->size_ = 0;
+}
+
+void LinkedList::print(void) {
+    std::cout << this->string() << std::endl;
+}
+
+std::string LinkedList::string(void) {
+    std::string str = "LinkedList(";
+    LinkedList::Node *current = this->head_;
+    while (current != nullptr) {
+        str += std::to_string(current->data());
+        current = current->next();
+        if (current != nullptr) {
+            str += ", ";
+        }
+    }
+    str += ")";
+
+    return str;
+}
+
+void LinkedList::append(int data) {
+    LinkedList::Node *node = new LinkedList::Node(data);
+    if (this->head_ == nullptr) {
+        this->head_ = node;
+        this->tail_ = node;
+    } else {
+        this->tail_->next(node);
+        this->tail_ = node;
+    }
+    this->size_++;
+}
+
+void LinkedList::prepend(int data) {
+    LinkedList::Node *node = new LinkedList::Node(data);
+    if (this->head_ == nullptr) {
+        this->head_ = node;
+        this->tail_ = node;
+    } else {
+        node->next(this->head_);
+        this->head_ = node;
+    }
+    this->size_++;
+}
+
+void LinkedList::insert(int index, int data) {
+    if (index < 0 || index > this->size_) {
+        throw std::out_of_range("Index out of range");
+    }
+
+    if (index == 0) {
+        this->prepend(data);
+    } else if (index == this->size_) {
+        this->append(data);
+    } else {
+        LinkedList::Node *node = new LinkedList::Node(data);
+        LinkedList::Node *prev = this->get(index - 1);
+        node->next(prev->next());
+        prev->next(node);
+        this->size_++;
+    }
+}
+
+LinkedList::Node *LinkedList::remove(int index) {
+    if (index < 0 || index >= this->size_) {
+        throw std::out_of_range("Index out of range");
+    }
+
+    LinkedList::Node *node = nullptr;
+    if (index == 0) {
+        node = this->pop_front();
+    } else if (index == this->size_ - 1) {
+        node = this->pop_back();
+    } else if (this->head_ == this->tail_) {
+        node = this->head_;
+        this->head_ = nullptr;
+        this->tail_ = nullptr;
+        this->size_--;
+    } else {
+        LinkedList::Node *prev = this->get(index - 1);
+        node = prev->next();
+        prev->next(node->next());
+        this->size_--;
+    }
+
+    return node;
+}
+
+LinkedList::Node *LinkedList::get(int index) {
+    if (index < 0 || index >= this->size_) {
+        throw std::out_of_range("Index out of range");
+    }
+
+    LinkedList::Node *current = this->head_;
+    for (int i = 0; i < index; i++) {
+        current = current->next();
+    }
+
+    return current;
+}
+
+int LinkedList::size(void) {
+    return this->size_;
+}
+
+void LinkedList::set(int index, int data) {
+    if (index < 0 || index >= this->size_) {
+        throw std::out_of_range("Index out of range");
+    }
+
+    LinkedList::Node *node = this->get(index);
+    node->data(data);
+}
+
+LinkedList::Node *LinkedList::pop_back(void) {
+    LinkedList::Node *node = this->tail_;
+    if (this->head_ == this->tail_) {
+        this->head_ = nullptr;
+        this->tail_ = nullptr;
+    } else {
+        LinkedList::Node *prev = this->get(this->size_ - 2);
+        prev->next(nullptr);
+        this->tail_ = prev;
+    }
+    this->size_--;
+    return node;
+}
+
+LinkedList::Node *LinkedList::pop_front(void) {
+    LinkedList::Node *node = this->head_;
+    if (this->head_ == this->tail_) {
+        this->head_ = nullptr;
+        this->tail_ = nullptr;
+    } else {
+        this->head_ = this->head_->next();
+    }
+    this->size_--;
+    return node;
+}
+
+void LinkedList::reverse(void) {
+    LinkedList::Node *prev = nullptr;
+    LinkedList::Node *current = this->head_;
+    LinkedList::Node *next = nullptr;
+    while (current != nullptr) {
+        next = current->next();
+        current->next(prev);
+        prev = current;
+        current = next;
+    }
+    this->tail_ = this->head_;
+    this->head_ = prev;
+}
+
+/* -----------------------------------------------------------------------------
+ *
+ * Method: find_middle_node
+ * 
+ * -----------------------------------------------------------------------------
+ * 
+ * Description:
+ *      Find the middle node of a linked list. It returns the index of the
+ *      middle node if the list is not empty, otherwise it returns -1.
+ * 
+ *      This method uses the "slow and fast" pointer technique to find the
+ *      middle node. The slow pointer moves one node at a time, while the fast
+ *      pointer moves two nodes at a time. When the fast pointer reaches the end
+ *      of the list, the slow pointer will be pointing to the middle node.
+ * 
+ *      Time complexity: O(n)
+ *      Space complexity: O(1)
+ * 
+ * Usage:
+ *      int idx = list->find_middle_node();
+ * 
+ * Returns:
+ *      The index of the middle node if the list is not empty, otherwise it
+ *      returns -1.
+ * 
+ * -------------------------------------------------------------------------- */
+int LinkedList::find_middle_node(void) {
+    int idx = -1;
+    if (this->head_ == nullptr) {
+        return idx;
+    }
+    LinkedList::Node *slow = this->head_;
+    LinkedList::Node *fast = this->head_;
+    idx = 0;
+    while (fast != nullptr && fast->next() != nullptr) {
+        idx++;
+        slow = slow->next();
+        fast = fast->next()->next();
+    }
+    return idx;
+}
+
+#endif  /* LINKEDLIST_HPP */


### PR DESCRIPTION
Implemented the find_middle_node() method in LinkedList.cpp, leveraging the slow and fast pointer technique to efficiently determine the index of the middle node in a linked list. The method returns -1 for empty lists and considers the second middle node for lists with an even number of elements.

- Added find_middle_node() method
- Updated README.md with comprehensive documentation

Contributions welcome!